### PR TITLE
Disable noise suppression for microphone

### DIFF
--- a/audio/audio_platform_info.xml
+++ b/audio/audio_platform_info.xml
@@ -34,6 +34,8 @@
         <device name="SND_DEVICE_IN_UNPROCESSED_QAUD_MIC" acdb_id="146"/>
         <device name="SND_DEVICE_IN_UNPROCESSED_HEADSET_MIC" acdb_id="147"/>
         <device name="SND_DEVICE_OUT_VOICE_SPEAKER" acdb_id="15" />
+        <device name="SND_DEVICE_IN_HANDSET_STEREO_DMIC_EF" acdb_id="69"/>
+        <device name="SND_DEVICE_IN_HANDSET_STEREO_DMIC" acdb_id="69"/>
     </acdb_ids>
     <bit_width_configs>
         <device name="SND_DEVICE_OUT_SPEAKER" bit_width="24"/>


### PR DESCRIPTION
Because of aggressive NS algorithm, many details are muted and lost. This change disables this algorithm on device that is used when recording video via camcorder.
The value 69 is undocumented and found via trial-and-error method, just like all other values in acdb-ids tag.
More info here: https://forum.xda-developers.com/oneplus-3/themes/mod-oneplus-3-audio-mods-t3407025/page41